### PR TITLE
TREV-238: Added support for importing csv-files with test examples

### DIFF
--- a/integration-test/__snapshots__/import.integration-test.ts.snap
+++ b/integration-test/__snapshots__/import.integration-test.ts.snap
@@ -1,6 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GET /import positive should return created childminders 1`] = `
+exports[`GET /import csv positive should return created evaka areas 1`] = `
+Object {
+  "inserts": Array [
+    Array [
+      Object {
+        "name": "Etelä",
+        "shortname": "etela",
+      },
+      Object {
+        "name": "Itä",
+        "shortname": "ita",
+      },
+      Object {
+        "name": "Länsi",
+        "shortname": "lansi",
+      },
+    ],
+  ],
+  "tables": Array [
+    "evaka_areas",
+  ],
+}
+`;
+
+exports[`GET /import csv positive should return created unitmaps 1`] = `
+Object {
+  "inserts": Array [
+    Array [
+      Object {
+        "effica_id": 18,
+        "evaka_id": "8eb2ca00-d40f-11eb-b97b-5b7a72ae2099",
+      },
+      Object {
+        "effica_id": 13,
+        "evaka_id": "8eb2caf0-d40f-11eb-b97b-5f3e4474ff3b",
+      },
+      Object {
+        "effica_id": 19,
+        "evaka_id": "8eb2cb86-d40f-11eb-b97b-735b4884eacd",
+      },
+      Object {
+        "effica_id": 272,
+        "evaka_id": "8eb2cc12-d40f-11eb-b97b-9f74a63003ec",
+      },
+      Object {
+        "effica_id": null,
+        "evaka_id": "8eb2cc9e-d40f-11eb-b97b-97c7553247ee",
+      },
+    ],
+  ],
+  "tables": Array [
+    "unitmap",
+  ],
+}
+`;
+
+exports[`GET /import xml positive should return created childminders 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -20,7 +76,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created codes 1`] = `
+exports[`GET /import xml positive should return created codes 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -104,7 +160,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created decisions 1`] = `
+exports[`GET /import xml positive should return created decisions 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -135,7 +191,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created departments 1`] = `
+exports[`GET /import xml positive should return created departments 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -171,7 +227,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created families 1`] = `
+exports[`GET /import xml positive should return created families 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -225,7 +281,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created feedeviations 1`] = `
+exports[`GET /import xml positive should return created feedeviations 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -263,7 +319,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created income  1`] = `
+exports[`GET /import xml positive should return created income  1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -291,7 +347,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created incomerows 1`] = `
+exports[`GET /import xml positive should return created incomerows 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -319,7 +375,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created persons 1`] = `
+exports[`GET /import xml positive should return created persons 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -401,7 +457,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created placementextents 1`] = `
+exports[`GET /import xml positive should return created placementextents 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -431,7 +487,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created placements 1`] = `
+exports[`GET /import xml positive should return created placements 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -461,7 +517,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should return created units 1`] = `
+exports[`GET /import xml positive should return created units 1`] = `
 Object {
   "inserts": Array [
     Array [
@@ -499,7 +555,7 @@ Object {
 }
 `;
 
-exports[`GET /import positive should work even if XML elements have mixed case 1`] = `
+exports[`GET /import xml positive should work even if XML elements have mixed case 1`] = `
 Object {
   "inserts": Array [
     Array [

--- a/integration-test/data/evaka_areas/evaka_areas.csv
+++ b/integration-test/data/evaka_areas/evaka_areas.csv
@@ -1,0 +1,4 @@
+﻿name|shortname
+Etelä|etela
+Itä|ita
+Länsi|lansi

--- a/integration-test/data/unitmap/unitmap.csv
+++ b/integration-test/data/unitmap/unitmap.csv
@@ -1,0 +1,6 @@
+﻿effica_id|evaka_id
+18| 8eb2ca00-d40f-11eb-b97b-5b7a72ae2099
+13|8eb2caf0-d40f-11eb-b97b-5f3e4474ff3b
+19|8eb2cb86-d40f-11eb-b97b-735b4884eacd
+272|8eb2cc12-d40f-11eb-b97b-9f74a63003ec
+|8eb2cc9e-d40f-11eb-b97b-97c7553247ee

--- a/integration-test/transform.integration-test.ts
+++ b/integration-test/transform.integration-test.ts
@@ -1,8 +1,7 @@
-import pgPromise from "pg-promise"
 import request from "supertest"
 import app from "../src/app"
 import db from "../src/db/db"
-import { getMigrationSchema } from "../src/util/queryTools"
+import { dropTable } from "../src/util/queryTools"
 
 const baseUrl = "/transform"
 
@@ -12,16 +11,6 @@ const baseDataTables = ["person", "codes"]
 const personExpectation = {
     id: expect.any(String),
     date_of_birth: expect.any(String)
-}
-
-const dropTable = async (tableName: string, t?: pgPromise.ITask<{}>) => {
-    const query = `DROP TABLE IF EXISTS ${getMigrationSchema()}${tableName};`
-    if (!t) {
-        return await db.tx(async t => t.any(query))
-    } else {
-        return await t.any(query)
-    }
-
 }
 
 const importTable = async (tableName: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/luxon": "^1.26.5",
+        "csvtojson": "^2.0.10",
         "express": "^4.17.1",
         "fast-xml-parser": "^3.19.0",
         "luxon": "^1.27.0",
@@ -1462,6 +1463,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1977,6 +1983,33 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/csvtojson/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -3276,6 +3309,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -4173,8 +4211,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -8494,6 +8531,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -8911,6 +8953,26 @@
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true
+        }
+      }
+    },
+    "csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
         }
       }
     },
@@ -9910,6 +9972,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -10615,8 +10682,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@types/luxon": "^1.26.5",
+    "csvtojson": "^2.0.10",
     "express": "^4.17.1",
     "fast-xml-parser": "^3.19.0",
     "luxon": "^1.27.0",

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -1,9 +1,9 @@
 import express from "express"
-import { importXmlData } from "../import/service"
+import { importFileData } from "../import/service"
 import { readFilesFromDir } from "../io/io"
 import { FileDescriptor, ImportOptions } from "../types"
-import { time, timeEnd } from "../util/timing"
 import { ErrorWithCause } from "../util/error"
+import { time, timeEnd } from "../util/timing"
 
 const router = express.Router();
 router.get("/", async (req, res, next) => {
@@ -14,7 +14,7 @@ router.get("/", async (req, res, next) => {
     const importOptions: ImportOptions = { path, returnAll: req.query.returnAll === "true" }
     try {
         const files: FileDescriptor[] = await readFilesFromDir(path)
-        const importResult = await importXmlData(files, importOptions)
+        const importResult = await importFileData(files, importOptions)
         res.status(200).json(importResult)
     } catch (err) {
         next(new ErrorWithCause(`Import operation failed, transaction rolled back:`, err))

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,5 +13,9 @@ export const config = {
         parseNodeValue: true,
         arrayMode: true,
         trimValues: true
+    },
+    csvParserOptions: {
+        trim: true,
+        delimiter: "|"
     }
 }

--- a/src/mapping/sourceMapping.ts
+++ b/src/mapping/sourceMapping.ts
@@ -1,4 +1,4 @@
-import { activityParser, codeNumericParser, dateParser, nullForcingTextParser, numericBooleanParser } from "../parsers"
+import { activityParser, codeNumericParser, dateParser, nullForcingTextParser, numericBooleanParser, stringToNumericParser } from "../parsers"
 import { TypeMapping } from "../types"
 
 
@@ -157,3 +157,13 @@ export const efficaTableMapping: TypeMapping = {
 }
 
 
+export const extTableMapping: TypeMapping = {
+    evaka_areas: {
+        name: { type: "text", parser: nullForcingTextParser },
+        shortname: { type: "text", parser: nullForcingTextParser }
+    },
+    unitmap: {
+        effica_id: { type: "integer", parser: stringToNumericParser },
+        evaka_id: { type: "uuid", parser: nullForcingTextParser }
+    }
+}

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -12,3 +12,4 @@ export const dateParser = (v: string): string | null => {
 }
 export const booleanParser = (v: boolean): boolean => v === true
 export const codeNumericParser = (v: number | null | undefined) => v == null || v === 0 ? null : v
+export const stringToNumericParser = (v: null | string) => v == null || v === "" || v === " " ? null : +v 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type FileDescriptor = { fileName: string, data: any, table: TableDescriptor }
+export type FileDescriptor = { fileName: string, data: any, table: TableDescriptor, mapping: TypeMapping }
 export type TableDescriptor = { tableName: string, columns: ColumnDescriptor[] }
 export type ColumnDescriptor = { columnName: string, sqlType: SqlType }
 

--- a/src/util/queryTools.ts
+++ b/src/util/queryTools.ts
@@ -1,5 +1,6 @@
 import pgPromise, { QueryFile } from "pg-promise"
 import { config } from "../config"
+import db from "../db/db"
 
 export const wrapWithReturning = (tableName: string, insertQuery: string, isDataReturned: boolean = false) => {
     return isDataReturned ?
@@ -14,6 +15,16 @@ export const runQueryFile = async (path: string, t: pgPromise.ITask<{}>, isDataR
 
 export const runQuery = async (query: string, t: pgPromise.ITask<{}>, isDataReturned: boolean = false) => {
     return isDataReturned ? await t.any(query) : await t.none(query)
+}
+
+export const dropTable = async (tableName: string, t?: pgPromise.ITask<{}>) => {
+    const query = `DROP TABLE IF EXISTS ${getMigrationSchema()}${tableName};`
+    if (!t) {
+        return await db.tx(async t => t.any(query))
+    } else {
+        return await t.any(query)
+    }
+
 }
 
 export const getMigrationSchema = () => config.migrationSchema ? `${config.migrationSchema}.` : ""


### PR DESCRIPTION
- refactored import-api to be able to handle csv-files (with header row, delimiter "|")
- added example csv-files to test data
- added mapping for evaka areas and unit map
- added import integration tests for above mappings