### PR TITLE
Maintain ids between migrations

### DIFF
--- a/integration-test/__snapshots__/import.integration-test.ts.snap
+++ b/integration-test/__snapshots__/import.integration-test.ts.snap
@@ -415,6 +415,7 @@ Object {
         "factor": "0",
         "familysize": 5,
         "grandtotal": "10",
+        "guid": "10",
         "paydecision": "1",
         "personid": "010619A9501",
         "startdate": Any<String>,
@@ -641,7 +642,7 @@ Object {
   "inserts": Array [
     Array [
       Object {
-        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}",
+        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa1}",
         "homemunicipality": 2,
         "mothertongue": 1,
         "nationality": 3,
@@ -657,7 +658,7 @@ Object {
         "secretaddress": false,
       },
       Object {
-        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}",
+        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa2}",
         "homemunicipality": 2,
         "mothertongue": 1,
         "nationality": null,
@@ -673,7 +674,7 @@ Object {
         "secretaddress": false,
       },
       Object {
-        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}",
+        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa3}",
         "homemunicipality": 2,
         "mothertongue": 1,
         "nationality": 3,
@@ -689,7 +690,7 @@ Object {
         "secretaddress": true,
       },
       Object {
-        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}",
+        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa4}",
         "homemunicipality": 2,
         "mothertongue": 1,
         "nationality": 3,
@@ -705,7 +706,7 @@ Object {
         "secretaddress": false,
       },
       Object {
-        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}",
+        "guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa5}",
         "homemunicipality": 2,
         "mothertongue": 1,
         "nationality": 3,

--- a/integration-test/__snapshots__/transform.integration-test.ts.snap
+++ b/integration-test/__snapshots__/transform.integration-test.ts.snap
@@ -18,6 +18,7 @@ Object {
     Object {
       "child_id": Any<String>,
       "duedate": "2021-11-29T00:00:00.000Z",
+      "effica_guid": "12F28AA0-E059-4203-98F9-EE3D37738B99",
       "effica_id": 12345,
       "guardian_id": Any<String>,
       "id": Any<String>,
@@ -199,6 +200,7 @@ Array [
   Object {
     "backup_phone": "",
     "date_of_birth": Any<String>,
+    "effica_guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa1}",
     "effica_ssn": "020967-9992",
     "email": "fake@notmaildomain.notext",
     "first_name": "Aimo",
@@ -216,6 +218,7 @@ Array [
   Object {
     "backup_phone": "",
     "date_of_birth": Any<String>,
+    "effica_guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa2}",
     "effica_ssn": "020288-TP01",
     "email": "fake2@notmaildomain.notext",
     "first_name": "Teppo",
@@ -233,6 +236,7 @@ Array [
   Object {
     "backup_phone": "",
     "date_of_birth": Any<String>,
+    "effica_guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa3}",
     "effica_ssn": "180476-998M",
     "email": "fake3@notmaildomain.notext",
     "first_name": "Hilda",
@@ -250,6 +254,7 @@ Array [
   Object {
     "backup_phone": "222-2222223",
     "date_of_birth": Any<String>,
+    "effica_guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa4}",
     "effica_ssn": "010619A9501",
     "email": "fake3@notmaildomain.notext",
     "first_name": "Christian",
@@ -267,6 +272,7 @@ Array [
   Object {
     "backup_phone": "222-2222223",
     "date_of_birth": Any<String>,
+    "effica_guid": "{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa5}",
     "effica_ssn": "251118A9509",
     "email": "fake3@notmaildomain.notext",
     "first_name": "Camilla",
@@ -384,6 +390,7 @@ Object {
       "co_payment": 0,
       "decision_number": "1",
       "effica_decision_date": "2020-12-01T00:00:00.000Z",
+      "effica_guid": "10",
       "effica_ssn": "010619A9501",
       "family_size": 5,
       "final_co_payment": 100,

--- a/integration-test/data/decisions/decisions.xml
+++ b/integration-test/data/decisions/decisions.xml
@@ -25,4 +25,5 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <familysize>5</familysize>
     <totalsum>10</totalsum>
     <grandtotal>10</grandtotal>
+    <guid>10</guid>
 </decision>

--- a/integration-test/data/person/person.xml
+++ b/integration-test/data/person/person.xml
@@ -18,7 +18,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <mothertongue>1</mothertongue>
     <nationality>3</nationality>
     <homemunicipality>2</homemunicipality>
-    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}</guid>
+    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa1}</guid>
 </person>
 <person>
     <personid>020288-TP01</personid>
@@ -34,7 +34,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <mothertongue>1</mothertongue>
     <nationality>0</nationality>
     <homemunicipality>2</homemunicipality>
-    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}</guid>
+    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa2}</guid>
 </person>
 <person>
     <personid>180476-998M</personid>
@@ -50,7 +50,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <mothertongue>1</mothertongue>
     <nationality>3</nationality>
     <homemunicipality>2</homemunicipality>
-    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}</guid>
+    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa3}</guid>
 </person>
 <person>
     <personid>010619A9501</personid>
@@ -66,7 +66,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <mothertongue>1</mothertongue>
     <nationality>3</nationality>
     <homemunicipality>2</homemunicipality>
-    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}</guid>
+    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa4}</guid>
 </person>
 <person>
     <personid>251118A9509</personid>
@@ -82,5 +82,5 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <mothertongue>1</mothertongue>
     <nationality>3</nationality>
     <homemunicipality>2</homemunicipality>
-    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa}</guid>
+    <guid>{AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa5}</guid>
 </person>

--- a/integration-test/import.integration-test.ts
+++ b/integration-test/import.integration-test.ts
@@ -5,12 +5,12 @@
 import request from "supertest"
 import app from "../src/app"
 import db from "../src/db/db"
+import { initDb } from "../src/init"
 import { errorCodes } from "../src/util/error"
 import { dropTable } from "../src/util/queryTools"
 import { setupTables } from "../src/util/testTools"
 
 const baseUrl = "/import"
-let cleanUps: string[] = []
 
 const tables = ["person", "codes", "income", "incomerows", "families",
     "units", "departments", "placements", "placementextents", "decisions",
@@ -29,25 +29,17 @@ const openDateRange: DateRangeExpectation = {
 }
 
 beforeAll(async () => {
-    await Promise.all(tables.map(table => dropTable(table)))
+    await initDb()
 })
 
-beforeEach(() => { })
-afterEach(async () => {
-    for (const table of cleanUps) {
+beforeEach(async () => {
+    for (const table of tables) {
         await dropTable(table)
     }
-    cleanUps = []
 })
 
 afterAll(async () => {
-    try {
-        for (const table of tables) {
-            await dropTable(table)
-        }
-    } finally {
-        return db.$pool.end()
-    }
+    await db.$pool.end()
 })
 
 // POSITIVE CASES
@@ -169,7 +161,6 @@ describe("GET /import csv positive", () => {
         return await positiveImportSnapshotTest("evaka_unit_manager")
     })
     it("should return created evaka daycares", async () => {
-        cleanUps = ["evaka_areas"]
         await setupTables(["evaka_areas", "evaka_unit_manager"])
         return await positiveImportSnapshotTest("evaka_daycare")
     })

--- a/integration-test/transfer.integration-test.ts
+++ b/integration-test/transfer.integration-test.ts
@@ -5,6 +5,7 @@
 import request from "supertest"
 import app from "../src/app"
 import db from "../src/db/db"
+import { initDb } from "../src/init"
 import { dropTable, truncateEvakaTable } from "../src/util/queryTools"
 import { setupTable, setupTransfers, setupTransformations } from "../src/util/testTools"
 
@@ -135,6 +136,8 @@ const voucherValueDecisionExpectation = {
 }
 
 beforeAll(async () => {
+    await initDb()
+
     for await (const table of baseDataTables) {
         await setupTable(table)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,19 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import app from "./app"
-import { config } from "./config"
+import app from "./app";
+import { config } from "./config";
+import { initDb } from "./init";
 
-app.listen(config.port, () => {
-    console.log(`Parser app listening at http://localhost:${config.port}`)
-})
-
+Promise.all([initDb()])
+    .then(() => {
+        app.listen(config.port, () => {
+            console.log(
+                `Parser app listening at http://localhost:${config.port}`
+            );
+        });
+    })
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2021 City of Tampere
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import migrationDb from "./db/db";
+import { baseQueryParameters, runQueryFile } from "./util/queryTools";
+
+export const initDb = async () => {
+    return await migrationDb.tx(async (t) => {
+        await runQueryFile("init.sql", t, baseQueryParameters);
+        await runQueryFile("functions.sql", t, baseQueryParameters);
+    });
+};

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -88,6 +88,7 @@ const collectTableDescription = (tableName: string, data: any, mapping: TypeMapp
     return {
         tableName,
         columns: collectDataColumnDescriptions(tableName, tableDef, data[0]),
+        primaryKeys: tableDef.primaryKeys,
         tableQueryFunction: tableDef.tableQueryFunction
     }
 }

--- a/src/mapping/sourceMapping.ts
+++ b/src/mapping/sourceMapping.ts
@@ -23,7 +23,8 @@ export const efficaTableMapping: TypeMapping = {
             status: { sqlType: "integer", parser: nullForcingTextParser },
             careid: { sqlType: "integer", parser: nullForcingTextParser },
             guid: { sqlType: "text", parser: nullForcingTextParser }
-        }
+        },
+        primaryKeys: ["guid"],
     },
     applicationrows: {
         tableName: "applicationrows",
@@ -108,7 +109,8 @@ export const efficaTableMapping: TypeMapping = {
             nationality: { sqlType: "integer", parser: codeNumericParser },
             homemunicipality: { sqlType: "integer", parser: codeNumericParser },
             guid: { sqlType: "text", parser: nullForcingTextParser }
-        }
+        },
+        primaryKeys: ["guid"],
     },
     areas: {
         tableName: "areas",
@@ -220,7 +222,8 @@ export const efficaTableMapping: TypeMapping = {
             totalsum: { sqlType: "numeric", parser: nullForcingTextParser },
             grandtotal: { sqlType: "numeric", parser: nullForcingTextParser },
             guid: { sqlType: "text", parser: nullForcingTextParser }
-        }
+        },
+        primaryKeys:["guid"],
     },
     childminders: {
         tableName: "childminders",

--- a/src/transfer/application.ts
+++ b/src/transfer/application.ts
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { ITask } from "pg-promise";
-import { config } from "../config";
 import migrationDb from "../db/db";
-import { runQuery, runQueryFile, selectFromTable } from "../util/queryTools";
+import {
+    baseQueryParameters,
+    runQuery,
+    runQueryFile,
+    selectFromTable,
+} from "../util/queryTools";
 
 export const transferApplicationData = async (returnAll: boolean = false) => {
     return migrationDb.tx(async (t) => {
@@ -15,13 +19,8 @@ export const transferApplicationData = async (returnAll: boolean = false) => {
     });
 };
 
-const queryParameters = {
-    migrationSchema: config.migrationSchema,
-    extensionSchema: config.extensionSchema,
-};
-
 const transferApplications = async <T>(t: ITask<T>, returnAll: boolean) => {
-    await runQueryFile("transfer-application.sql", t, queryParameters);
+    await runQueryFile("transfer-application.sql", t, baseQueryParameters);
 
     const applications = await runQuery(
         selectFromTable("application", "", returnAll, ["sentdate"]),

--- a/src/transfer/voucher-value-decisions.ts
+++ b/src/transfer/voucher-value-decisions.ts
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { config } from "../config";
 import migrationDb from "../db/db";
-import { runQuery, runQueryFile, selectFromTable } from "../util/queryTools";
-
-const queryParameters = {
-    migrationSchema: config.migrationSchema,
-    extensionSchema: config.extensionSchema,
-};
+import {
+    baseQueryParameters,
+    runQuery,
+    runQueryFile,
+    selectFromTable,
+} from "../util/queryTools";
 
 export const transferVoucherValueDecisions = async (
     returnAll: boolean = false
 ) => {
     return await migrationDb.tx(async (t) => {
         await runQueryFile("transfer-voucher-value-decision.sql", t, {
-            ...queryParameters,
+            ...baseQueryParameters,
         });
         return await runQuery(
             selectFromTable("voucher_value_decision", "", returnAll, [

--- a/src/transform/application.ts
+++ b/src/transform/application.ts
@@ -6,7 +6,12 @@ import { ITask } from "pg-promise";
 import { config } from "../config";
 import migrationDb from "../db/db";
 import { APPLICATION_STATUS_MAPPINGS } from "../mapping/citySpecific";
-import { runQuery, runQueryFile, selectFromTable } from "../util/queryTools";
+import {
+    baseQueryParameters,
+    runQuery,
+    runQueryFile,
+    selectFromTable,
+} from "../util/queryTools";
 
 export const transformApplicationData = async (returnAll: boolean = false) => {
     return migrationDb.tx(async (t) => {
@@ -16,14 +21,9 @@ export const transformApplicationData = async (returnAll: boolean = false) => {
     });
 };
 
-const queryParameters = {
-    migrationSchema: config.migrationSchema,
-    extensionSchema: config.extensionSchema,
-};
-
 const transformApplications = async <T>(t: ITask<T>, returnAll: boolean) => {
     await runQueryFile("transform-application.sql", t, {
-        ...queryParameters,
+        ...baseQueryParameters,
         statusMappings: APPLICATION_STATUS_MAPPINGS[config.cityVariant],
     });
 

--- a/src/transform/placements.ts
+++ b/src/transform/placements.ts
@@ -5,7 +5,12 @@
 import { ITask } from "pg-promise";
 import { config } from "../config";
 import migrationDb from "../db/db";
-import { runQuery, runQueryFile, selectFromTable } from "../util/queryTools";
+import {
+    baseQueryParameters,
+    runQuery,
+    runQueryFile,
+    selectFromTable,
+} from "../util/queryTools";
 
 export const transformPlacementsData = async (returnAll: boolean = false) => {
     return migrationDb.tx(async (t) => {
@@ -16,14 +21,8 @@ export const transformPlacementsData = async (returnAll: boolean = false) => {
     });
 };
 
-const queryParameters = {
-    migrationSchema: config.migrationSchema,
-    extensionSchema: config.extensionSchema,
-};
-
 const transformPlacements = async <T>(t: ITask<T>, returnAll: boolean) => {
-    await runQueryFile("functions.sql", t, queryParameters);
-    await runQueryFile("transform-placement.sql", t, queryParameters);
+    await runQueryFile("transform-placement.sql", t, baseQueryParameters);
 
     const placements = await runQuery(
         selectFromTable("evaka_placement", config.migrationSchema, returnAll, [
@@ -46,7 +45,7 @@ const transformPlacements = async <T>(t: ITask<T>, returnAll: boolean) => {
 };
 
 const transformExtents = async <T>(t: ITask<T>, returnAll: boolean) => {
-    await runQueryFile("transform-placementextent.sql", t, queryParameters);
+    await runQueryFile("transform-placementextent.sql", t, baseQueryParameters);
 
     const serviceNeeds = await runQuery(
         selectFromTable(
@@ -68,5 +67,5 @@ const transformExtents = async <T>(t: ITask<T>, returnAll: boolean) => {
         t,
         true
     );
-    return { serviceNeeds, serviceNeedsTodo }
+    return { serviceNeeds, serviceNeedsTodo };
 };

--- a/src/transform/voucher-value-decisions.ts
+++ b/src/transform/voucher-value-decisions.ts
@@ -8,19 +8,19 @@ import {
     DECISION_STATUS_TYPE_MAPPINGS,
     VOUCHER_VALUE_DECISION_TYPES,
 } from "../mapping/citySpecific";
-import { runQuery, runQueryFile, selectFromTable } from "../util/queryTools";
-
-const queryParameters = {
-    migrationSchema: config.migrationSchema,
-    extensionSchema: config.extensionSchema,
-};
+import {
+    baseQueryParameters,
+    runQuery,
+    runQueryFile,
+    selectFromTable,
+} from "../util/queryTools";
 
 export const transformVoucherValueDecisionData = async (
     returnAll: boolean = false
 ) => {
     return await migrationDb.tx(async (t) => {
         await runQueryFile("transform-voucher-value-decision.sql", t, {
-            ...queryParameters,
+            ...baseQueryParameters,
             statusMappings: DECISION_STATUS_TYPE_MAPPINGS[config.cityVariant],
             types: VOUCHER_VALUE_DECISION_TYPES[config.cityVariant],
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 export type FileDescriptor = { fileName: string, data: any, table: TableDescriptor, mapping: TypeMapping }
-export type TableDescriptor = { tableName: string, columns: Record<string, ColumnDescriptor>, tableQueryFunction?: TableQueryFunction }
+export type TableDescriptor = { tableName: string, columns: Record<string, ColumnDescriptor>, primaryKeys?: string[], tableQueryFunction?: TableQueryFunction }
 export type ColumnDescriptor = { sqlType: SqlType, parser: Function }
 
 export type QueryOptions = {

--- a/src/util/queryTools.ts
+++ b/src/util/queryTools.ts
@@ -9,6 +9,11 @@ import db from "../db/db"
 import { TableDescriptor } from "../types"
 import { EfficaIncomeCodeMapping } from "../types/mappings"
 
+export const baseQueryParameters = {
+    migrationSchema: config.migrationSchema,
+    extensionSchema: config.extensionSchema,
+};
+
 export const wrapWithReturning = (tableName: string, insertQuery: string, isDataReturned: boolean = false, orderByFields: string[] = []) => {
     return isDataReturned ?
         `WITH rows AS ( ${insertQuery} RETURNING *) select * from rows ${createOrderBy(orderByFields)};` :
@@ -63,10 +68,11 @@ export const getExtensionSchemaPrefix = () => config.extensionSchema ? `${config
 export const createOrderBy = (orderByFields: string[]) => orderByFields.length > 0 ? `ORDER BY ${orderByFields.join(" ,")} ` : ""
 
 export const createGenericTableQueryFromDescriptor = (td: TableDescriptor): string => {
+    const primaryKeyStr = td.primaryKeys !== undefined ? `, PRIMARY KEY (${td.primaryKeys?.join(",")})` : ""
     return `CREATE TABLE IF NOT EXISTS 
         ${getMigrationSchemaPrefix()}
         ${td.tableName} 
-        (${Object.keys(td.columns).map(c => `${c} ${td.columns[c].sqlType}`).join(",")});`
+        (${Object.keys(td.columns).map(c => `${c} ${td.columns[c].sqlType}`).join(",")}${primaryKeyStr});`
 }
 
 export const createSqlConditionalForIncomeCodes = (mappings: EfficaIncomeCodeMapping[]) => {

--- a/src/util/sql/init.sql
+++ b/src/util/sql/init.sql
@@ -1,0 +1,12 @@
+-- SPDX-FileCopyrightText: 2021 City of Tampere
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+CREATE TABLE IF NOT EXISTS ${migrationSchema:name}.idmap (
+    type TEXT NOT NULL,
+    effica_guid TEXT NOT NULL,
+    evaka_id UUID NOT NULL,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (type, effica_guid)
+);


### PR DESCRIPTION
In eVaka it is possible to create URL to person, application and (voucher value) decision. To ease testing add support to maintain those identifiers between migrations.