### PR TITLE
TREV-424: Placement exclusion list implementation

### DIFF
--- a/integration-test/__snapshots__/import.integration-test.ts.snap
+++ b/integration-test/__snapshots__/import.integration-test.ts.snap
@@ -242,6 +242,21 @@ Object {
 }
 `;
 
+exports[`GET /import csv positive should return created placements exclusion 1`] = `
+Object {
+  "inserts": Array [
+    Array [
+      Object {
+        "placementnbr": 16,
+      },
+    ],
+  ],
+  "tables": Array [
+    "placements_exclusion",
+  ],
+}
+`;
+
 exports[`GET /import csv positive should return created unitmaps 1`] = `
 Object {
   "inserts": Array [
@@ -1084,6 +1099,15 @@ Object {
         "placementchildminder": "010101-TP99",
         "placementdepartmentcode": null,
         "placementnbr": 15,
+        "placementunitcode": null,
+        "startdate": Any<String>,
+      },
+      Object {
+        "enddate": null,
+        "personid": "251118A9509",
+        "placementchildminder": "010101-TP99",
+        "placementdepartmentcode": null,
+        "placementnbr": 16,
         "placementunitcode": null,
         "startdate": Any<String>,
       },

--- a/integration-test/data/placements/placements.xml
+++ b/integration-test/data/placements/placements.xml
@@ -49,3 +49,12 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <startdate>20210801</startdate>
     <enddate></enddate>
 </placement>
+<placement>
+    <placementnbr>16</placementnbr>
+    <personid>251118A9509</personid>
+    <placementunitcode>0</placementunitcode>
+    <placementdepartmentcode>0</placementdepartmentcode>
+    <placementchildminder>010101-TP99</placementchildminder>
+    <startdate>20210801</startdate>
+    <enddate></enddate>
+</placement>

--- a/integration-test/data/placements_exclusion/placements_exclusion.csv
+++ b/integration-test/data/placements_exclusion/placements_exclusion.csv
@@ -1,0 +1,2 @@
+placementnbr
+16

--- a/integration-test/data/placements_exclusion/placements_exclusion.csv.license
+++ b/integration-test/data/placements_exclusion/placements_exclusion.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 City of Tampere
+
+SPDX-License-Identifier: LGPL-2.1-or-later

--- a/integration-test/import.integration-test.ts
+++ b/integration-test/import.integration-test.ts
@@ -17,7 +17,7 @@ const tables = ["persons", "codes", "income", "incomerows", "families",
     "feedeviations", "childminders", "evaka_areas", "unitmap", "childmindermap",
     "dailyjournals", "dailyjournalrows",
     "applications", "applicationrows", "evaka_unit_manager", "evaka_daycare", "daycare_oid_map",
-    "families_exclusion"]
+    "families_exclusion", "placements_exclusion"]
 
 type DateRangeExpectation = { [key: string]: any }
 
@@ -97,7 +97,7 @@ describe("GET /import xml positive", () => {
     it("should return created placements", async () => {
         return await positiveImportSnapshotTest(
             "placements",
-            getTimeSeriesResultPattern(openDateRange, openDateRange, openDateRange, closedDateRange, openDateRange))
+            getTimeSeriesResultPattern(openDateRange, openDateRange, openDateRange, closedDateRange, openDateRange, openDateRange))
     })
 
     it("should return created placementextents", async () => {
@@ -192,6 +192,10 @@ describe("GET /import csv positive", () => {
     it("should return created families exclusion", async () => {
         return await positiveImportSnapshotTest(
             "families_exclusion")
+    })
+    it("should return created placements exclusion", async () => {
+        return await positiveImportSnapshotTest(
+            "placements_exclusion")
     })
 })
 

--- a/integration-test/transfer.integration-test.ts
+++ b/integration-test/transfer.integration-test.ts
@@ -22,6 +22,7 @@ const baseDataTables =
         "departments",
         "unitmap",
         "childmindermap",
+        "placements_exclusion",
         "placements",
         "extentmap",
         "placementextents",

--- a/integration-test/transform.integration-test.ts
+++ b/integration-test/transform.integration-test.ts
@@ -28,6 +28,7 @@ const baseDataTables =
         "extentmap",
         "unitmap",
         "childmindermap",
+        "placements_exclusion",
         "placements",
         "placementextents",
         "feedeviations",

--- a/src/mapping/sourceMapping.ts
+++ b/src/mapping/sourceMapping.ts
@@ -495,6 +495,15 @@ export const extTableMapping: TypeMapping = {
                 sqlType: "date", parser: nullDateParser
             }
         }
-    }
+    },
+    placements_exclusion: {
+        tableQueryFunction: createGenericExclusionTableQuery,
+        tableName: `placements${config.exclusionSuffix}`,
+        columns: {
+            placementnbr: {
+                sqlType: "integer", parser: stringToNumericParser
+            }
+        }
 
+    }
 }

--- a/src/util/sql/transform-placement.sql
+++ b/src/util/sql/transform-placement.sql
@@ -33,7 +33,7 @@ SELECT
     p.startdate,
     p.enddate,
     edg.id
-FROM ${migrationSchema:name}.placements p
+FROM ${migrationSchema:name}.filtered_placements_v p
 LEFT JOIN ${migrationSchema:name}.evaka_person ep ON ep.effica_ssn = p.personid
 LEFT JOIN ${migrationSchema:name}.unitmap um ON um.effica_id = p.placementunitcode
 LEFT JOIN ${migrationSchema:name}.evaka_daycare_group edg ON edg.effica_id = p.placementdepartmentcode


### PR DESCRIPTION
- added placement exclusion table description to source mapping
- modified placement transform to select data from the `migration.filtered_placements_v` instead of the data table
- created an integration test for placement exclusions
- tested in migration environment