### PR TITLE
Add existing evaka persons support

### DIFF
--- a/integration-test/__snapshots__/transform.integration-test.ts.snap
+++ b/integration-test/__snapshots__/transform.integration-test.ts.snap
@@ -337,6 +337,7 @@ Array [
     "postal_code": "00001",
     "restricted_details_enabled": false,
     "social_security_number": "020967-9992",
+    "source_system": "effica",
     "street_address": "Fakestreet 123",
   },
   Object {
@@ -355,6 +356,7 @@ Array [
     "postal_code": "00002",
     "restricted_details_enabled": false,
     "social_security_number": null,
+    "source_system": "effica",
     "street_address": "StreetStreet 321",
   },
   Object {
@@ -373,6 +375,7 @@ Array [
     "postal_code": "",
     "restricted_details_enabled": true,
     "social_security_number": "180476-998M",
+    "source_system": "effica",
     "street_address": "",
   },
   Object {
@@ -391,6 +394,7 @@ Array [
     "postal_code": "00001",
     "restricted_details_enabled": false,
     "social_security_number": "010619A9501",
+    "source_system": "effica",
     "street_address": "HideStreet 2",
   },
   Object {
@@ -409,6 +413,7 @@ Array [
     "postal_code": "12000",
     "restricted_details_enabled": false,
     "social_security_number": "251118A9509",
+    "source_system": "effica",
     "street_address": "HideStreet 2",
   },
   Object {
@@ -427,6 +432,7 @@ Array [
     "postal_code": "",
     "restricted_details_enabled": false,
     "social_security_number": "181101A9092",
+    "source_system": "effica",
     "street_address": "",
   },
 ]

--- a/src/transfer/person.ts
+++ b/src/transfer/person.ts
@@ -30,6 +30,7 @@ export const transferPersonData = async (returnAll: boolean = false) => {
             ${config.mockVtj ? `'2021-05-01'::timestamptz` : 'null'},
             ${config.mockVtj ? `'2021-05-01'::timestamptz` : 'null'}
         FROM ${getMigrationSchemaPrefix()}evaka_person p
+        ON CONFLICT (social_security_number) DO NOTHING
     `
     const insertQuery = wrapWithReturning("person", insertQueryPart, returnAll)
 


### PR DESCRIPTION
Citizens will create applications before the data migration (application_* tables). Login also creates some objects to database (person, guardian, child).

This PR adds support to handle case that person is already in the database.

I think we can ignore other tables; data migration will not create guardian rows and child rows already has `ON CONFLICT DO NOTHING`.