### PR TITLE
Support for multi-file import into one table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ npm run integration-test
 1. Place XML files of table data or CSV files of external data under a directory called `xml` under the project root.
    - this is the directory the application will read by default, individual requests can be configured to target different locations relative to project root
    - all data tables used in XML or CSV data must be typed and described in `src/mapping/sourceMapping.ts`
+   - by default the file name without extension is assumed to match the target table in the mapping
 2. Prepare a Postgres DB and configure the connection under `migrationDb` in `src/config.ts`
 3. Start the application with `npm start` 
 4. Send an HTTP GET request to `http://localhost:3000/import`
    - following query strings are recognized:
-     - `path`: directory path relative to project root to read for XML or CSV data, if missing, default path `/xml` will be used
-     - `returnAll`: default false, can be set to true in order to receive all inserted data as JSON in the response (for testing with smaller imports) 
+     - `path`: default: `/xml`,  directory path relative to project root to read for XML or CSV data
+     - `returnAll`: default: false, can be set to true in order to receive all inserted data as JSON in the response (for testing with smaller imports)
+     - `importTarget`: default: name of the read file without extension, can be used to give an explicit target table name for all files in the directory described by `path`, by default the table name is assumed to be the file name without extension (this parameter is useful for importing data split into several files with one request)
 
 ## Transforming imported data
 

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -13,11 +13,16 @@ const router = express.Router();
 router.get("/", async (req, res, next) => {
     time("**** Import total ", undefined, "*")
     const reqPath = req.query.path ?? "/xml"
+    const tableName = req.query.tableName
     const basePath = `${__dirname}/../..`
     const path = basePath + reqPath
-    const importOptions: ImportOptions = { path, returnAll: req.query.returnAll === "true" }
+    const importOptions: ImportOptions = {
+        path,
+        returnAll: req.query.returnAll === "true",
+        importTarget: typeof tableName === "string" ? tableName : undefined
+    }
     try {
-        const files: FileDescriptor[] = await readFilesFromDir(path)
+        const files: FileDescriptor[] = await readFilesFromDir(importOptions)
         const importResult = await importFileData(files, importOptions)
         res.status(200).json(importResult)
     } catch (err) {

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -13,13 +13,13 @@ const router = express.Router();
 router.get("/", async (req, res, next) => {
     time("**** Import total ", undefined, "*")
     const reqPath = req.query.path ?? "/xml"
-    const tableName = req.query.tableName
+    const importTarget = req.query.importTarget
     const basePath = `${__dirname}/../..`
     const path = basePath + reqPath
     const importOptions: ImportOptions = {
         path,
         returnAll: req.query.returnAll === "true",
-        importTarget: typeof tableName === "string" ? tableName : undefined
+        importTarget: typeof importTarget === "string" ? importTarget : undefined
     }
     try {
         const files: FileDescriptor[] = await readFilesFromDir(importOptions)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface TableQueryFunction { (td: TableDescriptor): string }
 export type TypeMapping = Record<string, TableDescriptor>
 export type SqlType = "text" | "numeric" | "boolean" | "timestamptz" | "integer" | "date" | "text[]" | "uuid" | "point" | "integer[]" | "daterange"
 
-export type ImportOptions = { returnAll: boolean, path: string }
+export type ImportOptions = { returnAll: boolean, path: string, importTarget?: string }
 export enum ImportType {
     Effica = "EFFICA",
     External = "EXT"


### PR DESCRIPTION
- added `importTarget` query param for import endpoint to designate an explicit target table for the files in the `path` directory
  - enables importing data regardless of the file name (apart from extension)
  - enables importing split data files with one request