### PR TITLE
TREV-444: Large file import in partitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "express": "^4.17.1",
         "fast-xml-parser": "^3.19.0",
         "luxon": "^1.27.0",
+        "n-readlines": "^1.0.1",
         "pg-promise": "^10.10.1",
         "ts-node": "^9.1.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.11",
         "@types/jest": "^26.0.23",
+        "@types/n-readlines": "^1.0.2",
         "@types/supertest": "^2.0.11",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
@@ -994,6 +996,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
+    },
+    "node_modules/@types/n-readlines": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/n-readlines/-/n-readlines-1.0.2.tgz",
+      "integrity": "sha512-jEpAbqwRa7bwMU44zSWE0ritLzeaHpEqPMBDCDRHp0Xle4V8xrE2jvqlVewm3KOFFjfYGaDrjpEk2j5Edr1Prw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "14.14.41",
@@ -4410,6 +4421,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/n-readlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.1.tgz",
+      "integrity": "sha512-z4SyAIVgMy7CkgsoNw7YVz40v0g4+WWvvqy8+ZdHrCtgevcEO758WQyrYcw3XPxcLxF+//RszTz/rO48nzD0wQ==",
+      "engines": {
+        "node": ">=6.x.x"
+      }
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -8156,6 +8175,15 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "@types/n-readlines": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/n-readlines/-/n-readlines-1.0.2.tgz",
+      "integrity": "sha512-jEpAbqwRa7bwMU44zSWE0ritLzeaHpEqPMBDCDRHp0Xle4V8xrE2jvqlVewm3KOFFjfYGaDrjpEk2j5Edr1Prw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
@@ -10827,6 +10855,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "n-readlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.1.tgz",
+      "integrity": "sha512-z4SyAIVgMy7CkgsoNw7YVz40v0g4+WWvvqy8+ZdHrCtgevcEO758WQyrYcw3XPxcLxF+//RszTz/rO48nzD0wQ=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/express": "^4.17.11",
     "@types/jest": "^26.0.23",
+    "@types/n-readlines": "^1.0.2",
     "@types/supertest": "^2.0.11",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
@@ -28,6 +29,7 @@
     "express": "^4.17.1",
     "fast-xml-parser": "^3.19.0",
     "luxon": "^1.27.0",
+    "n-readlines": "^1.0.1",
     "pg-promise": "^10.10.1",
     "ts-node": "^9.1.1"
   }

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import express from "express"
+import { config } from "../config"
 import { importFileData } from "../import/service"
 import { readFilesFromDir, readFilesFromDirAsPartitions } from "../io/io"
 import { FileDescriptor, ImportOptions, PartitionImportOptions } from "../types"
@@ -37,14 +38,14 @@ router.get("/partition", async (req, res, next) => {
     const importTarget = req.query.importTarget
     const basePath = `${__dirname}/../..`
     const path = basePath + reqPath
+    const maxBufferSize = req.query.bufferSize ?? config.defaultPartitionBufferSize
     const importOptions: PartitionImportOptions = {
         path,
-        returnAll: req.query.returnAll === "true",
-        importTarget: typeof importTarget === "string" ? importTarget : "no target"
+        bufferSize: +maxBufferSize,
+        importTarget: typeof importTarget === "string" ? importTarget : "no target set"
     }
     try {
         const importResult = await readFilesFromDirAsPartitions(importOptions)
-        //console.log(importResult)
         res.status(200).json(importResult)
     } catch (err) {
         next(new ErrorWithCause(`Import operation failed, transaction rolled back:`, err))

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -4,8 +4,8 @@
 
 import express from "express"
 import { importFileData } from "../import/service"
-import { readFilesFromDir } from "../io/io"
-import { FileDescriptor, ImportOptions } from "../types"
+import { readFilesFromDir, readFilesFromDirAsPartitions } from "../io/io"
+import { FileDescriptor, ImportOptions, PartitionImportOptions } from "../types"
 import { ErrorWithCause } from "../util/error"
 import { time, timeEnd } from "../util/timing"
 
@@ -24,6 +24,27 @@ router.get("/", async (req, res, next) => {
     try {
         const files: FileDescriptor[] = await readFilesFromDir(importOptions)
         const importResult = await importFileData(files, importOptions)
+        res.status(200).json(importResult)
+    } catch (err) {
+        next(new ErrorWithCause(`Import operation failed, transaction rolled back:`, err))
+    }
+    timeEnd("**** Import total ", undefined, "*")
+})
+
+router.get("/partition", async (req, res, next) => {
+    time("**** Import total ", undefined, "*")
+    const reqPath = req.query.path ?? "/xml"
+    const importTarget = req.query.importTarget
+    const basePath = `${__dirname}/../..`
+    const path = basePath + reqPath
+    const importOptions: PartitionImportOptions = {
+        path,
+        returnAll: req.query.returnAll === "true",
+        importTarget: typeof importTarget === "string" ? importTarget : "no target"
+    }
+    try {
+        const importResult = await readFilesFromDirAsPartitions(importOptions)
+        //console.log(importResult)
         res.status(200).json(importResult)
     } catch (err) {
         next(new ErrorWithCause(`Import operation failed, transaction rolled back:`, err))

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,5 +26,6 @@ export const config = {
     csvParserOptions: {
         trim: true,
         delimiter: "|"
-    }
+    },
+    partitionBufferSize: +(process.env.PARTITION_BUFFER_SIZE ?? 60000) //line buffer for partitioned file reading and data persisting
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,5 +27,5 @@ export const config = {
         trim: true,
         delimiter: "|"
     },
-    partitionBufferSize: +(process.env.PARTITION_BUFFER_SIZE ?? 60000) //line buffer for partitioned file reading and data persisting
+    defaultPartitionBufferSize: 60000 //line buffer for partitioned file reading and data persisting
 }

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -4,10 +4,16 @@
 
 import csv from "csvtojson/v2"
 import * as xmlParser from "fast-xml-parser"
+import { Dirent } from "fs"
 import { opendir, readFile } from "fs/promises"
+import LineReader from "n-readlines"
+import pgPromise from "pg-promise"
+import v8 from "v8"
 import { config } from "../config"
+import migrationDb from "../db/db"
+import { importFileDataWithExistingTx } from "../import/service"
 import { efficaTableMapping, extTableMapping } from "../mapping/sourceMapping"
-import { ColumnDescriptor, FileDescriptor, ImportOptions, ImportType, TableDescriptor, TypeMapping } from "../types"
+import { ColumnDescriptor, FileDescriptor, ImportOptions, ImportType, PartitionImportOptions, TableDescriptor, TypeMapping } from "../types"
 import { errorCodes, ErrorWithCause } from "../util/error"
 import { time, timeEnd } from "../util/timing"
 
@@ -116,4 +122,130 @@ const collectDataColumnDescriptions = (tableName: string, td: TableDescriptor, d
         dataDescription[columnKey] = columnDef
     })
     return dataDescription
+}
+
+export async function readFilesFromDirAsPartitions(importOptions: PartitionImportOptions): Promise<Record<string, any[]>> {
+    const results: Record<string, any[]> = {}
+    return await migrationDb.tx(async (t) => {
+        try {
+            const dir = await opendir(importOptions.path)
+
+            for await (const dirent of dir) {
+                if (dirent.isFile()) {
+                    const fileName = dirent.name.toLowerCase()
+                    if (fileName.endsWith(".license")) continue
+
+                    const fileInfo = fileName.split(".")
+                    const fileType = fileInfo[1]
+                    if (fileType === 'csv') {
+                        throw new Error("CSV partitioning not supported")
+                    }
+                    const importResult = await importFileInParts(importOptions, dirent, fileName, t)
+                    results[fileName] = importResult
+                }
+            }
+        } catch (err) {
+            throw new ErrorWithCause(`Parsing file data failed:`, err)
+        }
+        return results
+    })
+}
+
+const importFileInParts = async (importOptions: PartitionImportOptions, dirent: Dirent, fileName: string, t: pgPromise.ITask<{}>) => {
+    const memUse: number[] = []
+    let lines: string[] = []
+    let bufferString = ""
+    let line: Buffer | boolean
+    let lineNumber = 0
+    const maxBufferSize = importOptions.bufferSize
+
+    if (!importOptions.importTarget) {
+        throw new Error("Invalid import target defined")
+    }
+    const tableName = importOptions.importTarget
+    const elementColumnCount = Object.keys(efficaTableMapping[tableName]?.columns).length
+    if (!elementColumnCount) {
+        throw new Error(`No column definitions found for ${tableName}`)
+    }
+
+    //used buffer size must be a multiple of the target element size
+    const elementLineCount = elementColumnCount + 2
+    const lineLimit = Math.floor(maxBufferSize / elementLineCount) * elementLineCount
+
+    let results: any[] = []
+    const fullpath = `${importOptions.path}/${dirent.name}`
+    console.log(`Attempting to read at '${fullpath}'`)
+    const lineReader = new LineReader(fullpath)
+    let parts: number = 1
+    time(`'${dirent.name}' reading`)
+
+    const fileDesc = {
+        fileName: fileName,
+        table: efficaTableMapping[tableName],
+        mapping: efficaTableMapping,
+        importType: ImportType.Effica
+    }
+
+    //roll through the file using buffer
+    while (line = lineReader.next()) {
+        //lines.push(line.toString())
+        bufferString = `${bufferString}${line}`
+        lineNumber++
+
+        //parse, persist and clear buffer
+        if (lineNumber === lineLimit) {
+            //console.log(`Partition ${parts} for '${fileName}' into '${tableName}'`)
+            memUse[parts - 1] = v8.getHeapStatistics().used_heap_size / 1024 / 1024
+
+            let result = await persistXmlPartition({
+                ...fileDesc,
+                fileName: `${fileName}_part${parts}`,
+                data: processXmlPartitionString(bufferString, fileName)
+            },
+                importOptions, t)
+            results.push(result)
+            lineNumber = 0
+            lines = []
+            bufferString = ""
+            parts++
+        }
+    }
+
+    //check for overflow and persist
+    if (lines.length > 0) {
+        let result = await persistXmlPartition({
+            ...fileDesc,
+            fileName: parts === 1 ? fileName : `${fileName}_part${parts}`,
+            data: processXmlPartition(lines, fileName)
+        },
+            importOptions, t)
+
+        results.push(result)
+        lineNumber = 0
+        lines = []
+    }
+    console.log(`Buffer size: ${maxBufferSize} lines (${parts} partitions)`)
+    console.log(
+        {
+            maxHeapUse: `${Math.max(...memUse).toPrecision(5)} MB`,
+            avgHeapUse: `${(memUse.reduce((p, c) => p + c, 0) / memUse.length).toPrecision(5)} MB`
+        })
+
+    return results
+}
+
+
+const persistXmlPartition = async (fd: FileDescriptor, importOptions: PartitionImportOptions, t: pgPromise.ITask<{}>) => {
+    const result = importFileDataWithExistingTx([fd], importOptions, t)
+    return result;
+}
+
+const processXmlPartition = (parts: string[], fileName: string) => {
+    const result = stripXmlOverhead(xmlParser.parse(parts.join("\n"), config.xmlParserOptions), fileName)
+    return result
+}
+
+const processXmlPartitionString = (bufferString: string, fileName: string) => {
+    const result = stripXmlOverhead(xmlParser.parse(bufferString, config.xmlParserOptions), fileName)
+    return result
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type TypeMapping = Record<string, TableDescriptor>
 export type SqlType = "text" | "numeric" | "boolean" | "timestamptz" | "integer" | "date" | "text[]" | "uuid" | "point" | "integer[]" | "daterange"
 
 export type ImportOptions = { returnAll: boolean, path: string, importTarget?: string }
+export type PartitionImportOptions = { path: string, importTarget: string, bufferSize: number }
 export enum ImportType {
     Effica = "EFFICA",
     External = "EXT"

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type TypeMapping = Record<string, TableDescriptor>
 export type SqlType = "text" | "numeric" | "boolean" | "timestamptz" | "integer" | "date" | "text[]" | "uuid" | "point" | "integer[]" | "daterange"
 
 export type ImportOptions = { returnAll: boolean, path: string, importTarget?: string }
-export type PartitionImportOptions = { path: string, importTarget: string, bufferSize: number }
+export type PartitionImportOptions = { path: string, importTarget?: string, bufferSize: number }
 export enum ImportType {
     Effica = "EFFICA",
     External = "EXT"


### PR DESCRIPTION
- new "bypass" for large file imports
  - endpoint `import/partition` for requesting large file import in partitions
  - new query parameter `bufferSize` for controlling the max line size for the read buffer
    - smaller buffer = lower memory consumption, but more partitions -> more duration impact from overhead
- tested to keep heap usage relatively stable even with 2GB file size
- partition import operates more strictly than regular import
  - no support for CSV, only "Effica-style XML"
  - can only import into one table per request, several files still allowed
  - no filename recognition, `importTarget` must be defined in request
  - requires that the full column set from source table mapping is present in data, no support for partial data import
  - requires uniform line separation in data, element line length is assumed to be number of columns in source mapping + 2
 - enables importing large files without manual splitting or intervention on low resource machines