### PR TITLE
January data set update changes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
 
 export const config = {
     cityVariant: process.env.CITY_VARIANT ?? "tampere",
+    copyPersonsFromEvaka: process.env.COPY_PERSONS_FROM_EVAKA?.toUpperCase() === "TRUE",
     mockVtj: process.env.MOCK_VTJ?.toUpperCase() === "TRUE",
     port: process.env.PORT ?? 3000,
     isTimed: process.env.ISTIMED?.toUpperCase() === "TRUE",

--- a/src/transform/person.ts
+++ b/src/transform/person.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { config } from "../config"
 import migrationDb from "../db/db"
 import { getExtensionSchemaPrefix, getMigrationSchemaPrefix, runQuery, wrapWithReturning } from "../util/queryTools"
 
@@ -96,7 +97,9 @@ export const transformPersonData = async (returnAll: boolean = false) => {
 
     return await migrationDb.tx(async (t) => {
         await runQuery(tableQuery, t)
-        await runQuery(evakaPersonInsert, t)
+        if (config.copyPersonsFromEvaka) {
+            await runQuery(evakaPersonInsert, t)
+        }
         const ret = await runQuery(insertQuery, t, true)
         // maintain ids between migrations
         await runQuery(`

--- a/src/util/sql/transform-special-means.sql
+++ b/src/util/sql/transform-special-means.sql
@@ -16,7 +16,7 @@ WITH
 calendar AS (
     -- create full calendar from date ranges
     SELECT
-        child.effica_ssn,
+        sm.personid as effica_ssn,
         child.id AS child_id,
         (
             generate_series(

--- a/src/util/sql/transform-special-needs.sql
+++ b/src/util/sql/transform-special-needs.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS ${migrationSchema:name}.evaka_assistance_need;
 CREATE TABLE ${migrationSchema:name}.evaka_assistance_need (
     id UUID PRIMARY KEY DEFAULT ${extensionSchema:name}.uuid_generate_v1mc(),
-    effica_ssn TEXT,
+    effica_ssn TEXT NOT NULL,
     child_id UUID REFERENCES ${migrationSchema:name}.evaka_person,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,
@@ -16,7 +16,7 @@ WITH
 calendar AS (
     -- create full calendar from date ranges
     SELECT
-        child.effica_ssn,
+        sn.personid as effica_ssn,
         child.id AS child_id,
         (
             generate_series(

--- a/src/util/sql/transform-special-needs.sql
+++ b/src/util/sql/transform-special-needs.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS ${migrationSchema:name}.evaka_assistance_need;
 CREATE TABLE ${migrationSchema:name}.evaka_assistance_need (
     id UUID PRIMARY KEY DEFAULT ${extensionSchema:name}.uuid_generate_v1mc(),
-    effica_ssn TEXT NOT NULL,
+    effica_ssn TEXT,
     child_id UUID REFERENCES ${migrationSchema:name}.evaka_person,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,


### PR DESCRIPTION
Changes to facilitate January dataset update in migration environment:
- conditional copying of persons from evaka (not needed in migration dataset changes)
- effica_ssn cannot be assumed to exist for the source join, otherwise transform fails for every missing person before the cases can be collected into TODO-table