### PR TITLE
Varda transform fixes

### DIFF
--- a/integration-test/__snapshots__/varda.integration-test.ts.snap
+++ b/integration-test/__snapshots__/varda.integration-test.ts.snap
@@ -106,6 +106,7 @@ Array [
   Object {
     "evaka_person_id": Any<String>,
     "organizer_oid": "2.2.2.1",
+    "row_id": Any<String>,
     "varda_child_id": "11",
     "varda_person_id": "21",
     "varda_person_oid": "1.1.1.1",
@@ -113,6 +114,7 @@ Array [
   Object {
     "evaka_person_id": Any<String>,
     "organizer_oid": "2.2.2.2",
+    "row_id": Any<String>,
     "varda_child_id": "12",
     "varda_person_id": "22",
     "varda_person_oid": "1.1.1.2",
@@ -120,6 +122,7 @@ Array [
   Object {
     "evaka_person_id": Any<String>,
     "organizer_oid": "2.2.2.3",
+    "row_id": Any<String>,
     "varda_child_id": "13",
     "varda_person_id": "21",
     "varda_person_oid": "1.1.1.1",

--- a/integration-test/varda.integration-test.ts
+++ b/integration-test/varda.integration-test.ts
@@ -11,12 +11,12 @@ import { dropTable, truncateEvakaTables } from "../src/util/queryTools";
 import {
     setupTable,
     setupTransfer,
-    setupTransformation,
+    setupTransformation
 } from "../src/util/testTools";
 import {
     VardaClient,
     VardaV1Children,
-    VardaV1Person,
+    VardaV1Person
 } from "../src/util/varda-client";
 
 beforeAll(async () => {
@@ -24,16 +24,17 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+    await truncateEvakaTables(["varda_organizer_child", "person"]);
     await setupTable("persons");
     await setupTable("codes");
     await setupTransformation("persons");
     await setupTransfer("persons");
     await dropTable("varda_child");
     await dropTable("varda_person");
-    await truncateEvakaTables(["varda_organizer_child", "person"]);
 });
 
 afterAll(async () => {
+    await truncateEvakaTables(["varda_organizer_child", "person"]);
     await db.$pool.end();
 });
 

--- a/integration-test/varda.integration-test.ts
+++ b/integration-test/varda.integration-test.ts
@@ -160,6 +160,7 @@ it("should import, transform and transfer varda data", async () => {
 
 const transformExpectation = {
     evaka_person_id: expect.any(String),
+    row_id: expect.any(String),
 };
 
 const transferExpectation = {

--- a/src/transform/varda.ts
+++ b/src/transform/varda.ts
@@ -6,13 +6,13 @@ import migrationDb from "../db/db";
 import {
     baseQueryParameters,
     runQuery,
-    wrapWithReturning,
+    wrapWithReturning
 } from "../util/queryTools";
 
 export const transformVarda = async (returnAll: boolean = false) => {
     return await migrationDb.tx(async (t) => {
         await runQuery(tableSql, t, false, baseQueryParameters);
-        return await runQuery(
+        const result = await runQuery(
             wrapWithReturning(
                 "evaka_varda_organizer_child",
                 transformSql,
@@ -23,6 +23,8 @@ export const transformVarda = async (returnAll: boolean = false) => {
             true,
             baseQueryParameters
         );
+        await runQuery(todoSql, t, false, baseQueryParameters);
+        return result;
     });
 };
 
@@ -35,9 +37,20 @@ const tableSql = `
         varda_child_id BIGINT NOT NULL,
         organizer_oid TEXT NOT NULL
     );
+
+    DROP TABLE IF EXISTS $(migrationSchema:name).evaka_varda_organizer_child_todo;
+    CREATE TABLE $(migrationSchema:name).evaka_varda_organizer_child_todo (
+        evaka_person_id UUID,
+        varda_person_oid TEXT NOT NULL,
+        varda_person_id BIGINT NOT NULL,
+        varda_child_id BIGINT NOT NULL,
+        organizer_oid TEXT NOT NULL,
+        reason TEXT NOT NULL
+    );
 `;
 
-const transformSql = `
+const transformSql =
+    `
     INSERT INTO $(migrationSchema:name).evaka_varda_organizer_child
         (evaka_person_id, varda_person_oid, varda_person_id, varda_child_id, organizer_oid)
     SELECT
@@ -47,8 +60,69 @@ const transformSql = `
         END
     FROM $(migrationSchema:name).varda_child vc
     JOIN $(migrationSchema:name).varda_person vp ON vp.id = vc.henkilo_id
-    CROSS JOIN $(migrationSchema:name).evaka_person ep
-    WHERE upper(vp.etunimet) = upper(ep.first_name)
-        AND upper(vp.sukunimi) = upper(ep.last_name)
-        AND vp.syntyma_pvm = ep.date_of_birth
-`;
+    CROSS JOIN person ep
+    WHERE (
+        $(migrationSchema:name).normalize_text(vp.etunimet) =
+        $(migrationSchema:name).normalize_text(ep.first_name)
+      OR
+        $(migrationSchema:name).normalize_text(ep.first_name) ilike
+           '%' || $(migrationSchema:name).normalize_text(vp.kutsumanimi) || '%'
+        )
+      AND $(migrationSchema:name).normalize_text(ep.last_name) ilike
+          '%' || $(migrationSchema:name).normalize_text(vp.sukunimi) || '%'
+      AND vp.syntyma_pvm = ep.date_of_birth
+    `;
+
+const todoSql =
+    `
+    INSERT INTO $(migrationSchema:name).evaka_varda_organizer_child_todo
+    SELECT a.*, 'AMBIGUOUS MATCH TO EVAKA PERSON' as reason
+    FROM $(migrationSchema:name).evaka_varda_organizer_child a
+    JOIN $(migrationSchema:name).evaka_varda_organizer_child b on a.evaka_person_id = b.evaka_person_id
+        AND a.varda_person_id <> b.varda_person_id;
+
+    INSERT INTO $(migrationSchema:name).evaka_varda_organizer_child_todo
+    SELECT a.*, 'AMBIGUOUS MATCH TO VARDA PERSON' as reason
+    FROM $(migrationSchema:name).evaka_varda_organizer_child a
+    JOIN $(migrationSchema:name).evaka_varda_organizer_child b on a.varda_person_id = b.varda_person_id
+        AND a.evaka_person_id IS NOT NULL
+        AND b.evaka_person_id IS NOT NULL
+        AND a.evaka_person_id <> b.evaka_person_id;
+
+    DELETE FROM $(migrationSchema:name).evaka_varda_organizer_child a
+    WHERE EXISTS (
+        SELECT FROM $(migrationSchema:name).evaka_varda_organizer_child_todo b
+        WHERE b.evaka_person_id = a.evaka_person_id
+            AND b.varda_person_oid = a.varda_person_oid
+            AND b.varda_person_id = a.varda_person_id
+        );
+
+    INSERT INTO $(migrationSchema:name).evaka_varda_organizer_child_todo
+    SELECT null,
+            vp.henkilo_oid,
+            vp.id,
+            vc.id,
+            CASE
+                WHEN vc.paos_kytkin THEN vc.paos_organisaatio_oid
+                ELSE vc.vakatoimija_oid
+                END,
+            'MISSING EVAKA MATCH' as reason
+    FROM $(migrationSchema:name).varda_person vp
+                JOIN $(migrationSchema:name).varda_child vc ON vp.id = vc.henkilo_id
+    WHERE NOT EXISTS(
+            SELECT
+            FROM $(migrationSchema:name).varda_person k
+                        CROSS JOIN person ep
+            WHERE (
+                        $(migrationSchema:name).normalize_text(k.etunimet) =
+                        $(migrationSchema:name).normalize_text(ep.first_name)
+                    OR
+                        $(migrationSchema:name).normalize_text(ep.first_name) ilike
+                        '%' || $(migrationSchema:name).normalize_text(k.kutsumanimi) || '%'
+                )
+                AND $(migrationSchema:name).normalize_text(ep.last_name) ilike
+                    '%' || $(migrationSchema:name).normalize_text(k.sukunimi) || '%'
+                AND k.syntyma_pvm = ep.date_of_birth
+                AND k.id = vp.id
+    );
+    `

--- a/src/util/sql/functions.sql
+++ b/src/util/sql/functions.sql
@@ -62,3 +62,10 @@ BEGIN
     RAISE EXCEPTION 'Unsupported preschool daycare start date %', input;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+DROP FUNCTION IF EXISTS ${migrationSchema:name}.normalize_text(text) CASCADE;
+CREATE FUNCTION ${migrationSchema:name}.normalize_text(input text) RETURNS text AS $$
+BEGIN
+    RETURN upper(unaccent(replace(input, '''', '´')));
+END
+$$ LANGUAGE plpgsql IMMUTABLE;


### PR DESCRIPTION
- Switched transform Varda-mapping to be done using `public.person` instead of `migration.evaka_person`
  - enables more accurate matching to updated VTJ name data
  - corrections can be made to eVaka (duplicate person removal etc.) to reduce needless duplicates in Varda matching
- Added a string normalization function to reduce matching issues with marking differences in person data between Varda and eVaka (Effica)
- Added a `row_id` column to better differentiate matching issues in the transformation results
- Modified integration tests to allow the new column and `public.person` data usage (test data init is still messy)
- Added a more tolerant name matching scheme to reduce the number of missing matches
- Added TODO-structures to gauge duplicate and missing name matches for varda-data
  - full Varda-transformation still requires manual fixing of some missing and duplicate matches (case Tampere)